### PR TITLE
11.7.5 - SMC-1597: fix parameter string matching for arrow functions …

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -762,3 +762,6 @@ SMC-1645: made error messages more consistent, encapsulating mesh.component.meth
 ------------------
 - SMC-1597: fix $happn etc. parameter string matching for arrow functions
 
+11.7.5 2021-06-02
+------------------
+- SMC-1597: fix parameter string matching for arrow functions with parentheses in body not signature

--- a/lib/system/utilities.js
+++ b/lib/system/utilities.js
@@ -44,7 +44,7 @@ Object.defineProperty(module.exports, 'log', {
 
 module.exports.getFunctionParameters = function(fn) {
   // eslint-disable-next-line no-useless-escape
-  const FN_ARGS = /^(?:async +)?(?:function)?\s*[^\(]*\(\s*([^\)]*)\)|(?:async\s+)?\(?\s*([^\)]*).*=>.*/m;
+  const FN_ARGS = /^(?:async +)?(?:function)?\s*[^\(=>]*\(\s*([^\)]*)\)|(?:async\s+)?\(?\s*([^\)]*).*=>.*/m;
   const FN_ARG_SPLIT = /,/;
   const FN_ARG = /^\s*(_?)(.+?)\1\s*$/;
   const STRIP_COMMENTS = /((\/\/.*$)|(\/\*[\s\S]*?\*\/))/gm;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "happner-2",
-  "version": "11.7.4",
+  "version": "11.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "happner-2",
-  "version": "11.7.4",
+  "version": "11.7.5",
   "description": "distributed application engine with evented storage and mesh services",
   "main": "lib/mesh.js",
   "bin": {

--- a/test/unit/mesh/mesh.js
+++ b/test/unit/mesh/mesh.js
@@ -225,6 +225,7 @@ describe(tests.testName(__filename, 3), function() {
     tests.expect(moduleInst.module.instance.testMethod5['$happnSeq']).to.be(0);
     tests.expect(moduleInst.module.instance.testMethod6['$happnSeq']).to.be(0);
     tests.expect(moduleInst.module.instance.testMethod7['$happnSeq']).to.be(1);
+    tests.expect(moduleInst.module.instance.testMethod8['$happnSeq']).to.be(0);
   });
 
   it('tests the _updateElement method', function(done) {
@@ -711,6 +712,7 @@ describe(tests.testName(__filename, 3), function() {
         // prettier-ignore
         this.testMethod6 = ($happn) => $happn;
         this.testMethod7 = (param, $happn) => ({ $happn, param });
+        this.testMethod8 = $happn => $happn.emit('yay'); // test bugfix for parentheses in body rather than signature
         this.property1 = {};
       }
 


### PR DESCRIPTION
…with parentheses in body not signature